### PR TITLE
Add package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "angular-rich-text-diff",
+  "main": "angular-rich-text-diff.js",
+  "version": "0.2.3",
+  "authors": [
+    "Bill Long <bill@blackout.us>"
+  ],
+  "description": "A directive to diff two html strings without messing up the html. Intended for diffing rich text entered into a rich text editor such as textAngular.",
+  "keywords": [
+    "angular",
+    "rich",
+    "text",
+    "html",
+    "diff"
+  ],
+  "license": "MIT",
+  "homepage": "http://github.com/bill-long/angular-rich-text-diff",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "devDependencies": {
+    "dt-angular": "~1.2.16"
+  },
+  "dependencies": {
+    "diff-match-patch": "1.0.0"
+  }
+}


### PR DESCRIPTION
This change allows to install the package via npm. Changed `google-diff-match-patch` dependency from bower.json to `diff-match-patch`, it is available [here](https://www.npmjs.com/package/diff-match-patch)